### PR TITLE
Updated scripts to work with the latest hhvm docker image

### DIFF
--- a/docker/myStartupScript.sh
+++ b/docker/myStartupScript.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+mkdir -p /var/www/html/storage
+mkdir -p /var/www/html/bootstrap/cache
+
 # Make sure the webserver have write permissions
 chown -R www-data:www-data /var/www/html/storage/
 chown -R www-data:www-data /var/www/html/bootstrap/cache/
 
 # Start HHVM
-/usr/bin/hhvm -m server -c /etc/hhvm/server.ini -c /etc/hhvm/site.ini
+/usr/bin/hhvm -vServer.AllowRunAsRoot=1 -m server -c /etc/hhvm/server.ini -c /etc/hhvm/site.ini


### PR DESCRIPTION
The scripts crash without these changes.
I'm not sure if the storage and boostrap/cache directories are needed anymore because they don't seem to be included in the image. The script now creates those if they do not exist in any case.